### PR TITLE
feat: Add recursive Notion page downloader with YAML frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
 !CLAUDE.md
+
+# Environment files (contain secrets)
+.env
+.env.notion
+
+# Python cache
+__pycache__/
+scripts/__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Downloaded content (user-specific)
+downloaded/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/examples/.env.notion.example
+++ b/examples/.env.notion.example
@@ -1,0 +1,20 @@
+# Notion Configuration Example
+# Copy this file to .env.notion and fill in your actual values
+# NEVER commit .env.notion to git (it's in .gitignore)
+
+# Required: Notion integration token
+# Get from: https://www.notion.so/my-integrations
+# Format: ntn_followed by long alphanumeric string
+NOTION_TOKEN=ntn_your_integration_token_here
+
+# Optional but recommended: Default parent page ID for uploads
+# This is where new pages will be created as children
+# Get from your Notion page URL (the long ID at the end)
+# Example: https://notion.so/My-Page-abc123def456 → use abc123def456
+NOTION_PARENT_PAGE=your_default_parent_page_id_here
+
+# Notes:
+# 1. No quotes needed around values
+# 2. No spaces around the = sign
+# 3. Make sure to share your parent page with the integration in Notion
+# 4. To share: Open page → "..." menu → "Add connections" → Select your integration

--- a/guides/setup/configuration-guide.md
+++ b/guides/setup/configuration-guide.md
@@ -1,0 +1,293 @@
+---
+**PDA Tier**: 3 (Setup Guide)
+**Estimated Tokens**: ~700 tokens
+**Load Condition**: Configuration Intent - User needs setup help or config errors detected
+**Dependencies**: May load first-time-setup.md for complete walkthrough
+---
+
+# Configuration Guide
+
+## Token Budget
+
+**Tier 1**: 150 tokens *(loaded)*
+**Tier 2**: 600 tokens *(loaded)*
+**This Guide**: 700 tokens *(loading)*
+
+**Total**: 1,450 tokens
+**Status**: ✅ Within budget
+
+---
+
+## Required Configuration
+
+This skill requires two configuration values:
+
+1. **NOTION_TOKEN** (required) - Your Notion integration token
+2. **NOTION_PARENT_PAGE** (optional but recommended) - Default parent page ID for uploads
+
+---
+
+## Configuration Method 1: .env.notion File (Recommended)
+
+### Create .env.notion file
+
+Create a file named `.env.notion` in your project directory:
+
+```bash
+# In your project root or skill directory
+touch .env.notion
+```
+
+### Add configuration values
+
+Edit `.env.notion` and add:
+
+```bash
+NOTION_TOKEN=ntn_your_integration_token_here
+NOTION_PARENT_PAGE=your_default_parent_page_id
+```
+
+**Example**:
+```bash
+NOTION_TOKEN=ntn_1234567890abcdef1234567890abcdef123456789012345678901234
+NOTION_PARENT_PAGE=abc123def456789012345678901234
+```
+
+### File discovery
+
+The script automatically searches for `.env.notion` in:
+1. Current working directory
+2. Parent directories (walks up the tree)
+3. Continues until found or reaches root
+
+**This means**: You can put `.env.notion` in a parent directory and all subdirectories will find it.
+
+---
+
+## Configuration Method 2: Environment Variables
+
+Set environment variables in your shell:
+
+### Temporary (current session only)
+```bash
+export NOTION_TOKEN=ntn_your_token_here
+export NOTION_PARENT_PAGE=your_page_id
+```
+
+### Permanent (add to .bashrc or .zshrc)
+```bash
+# Add these lines to ~/.bashrc or ~/.zshrc
+export NOTION_TOKEN=ntn_your_token_here
+export NOTION_PARENT_PAGE=your_page_id
+```
+
+Then reload shell:
+```bash
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+---
+
+## Configuration Method 3: .env File (Alternative)
+
+The script also checks `.env` files (in addition to `.env.notion`):
+
+```bash
+# Create .env file
+touch .env
+
+# Add configuration
+NOTION_TOKEN=ntn_your_token_here
+NOTION_PARENT_PAGE=your_page_id
+```
+
+**Search order**:
+1. Environment variables
+2. `.env.notion` (current dir)
+3. `.env` (current dir)
+4. `.env.notion` (parent dirs)
+5. `.env` (parent dirs)
+
+---
+
+## Getting Your NOTION_TOKEN
+
+### Step 1: Create Notion Integration
+
+1. Go to https://www.notion.so/my-integrations
+2. Click "+ New integration"
+3. Give it a name (e.g., "Markdown Uploader")
+4. Select the workspace
+5. Click "Submit"
+
+### Step 2: Copy the Token
+
+1. After creating, you'll see "Internal Integration Token"
+2. Click "Show" then "Copy"
+3. Token format: `ntn_1234567890abcdef...` (very long string)
+4. Paste this into your `.env.notion` file as `NOTION_TOKEN=...`
+
+### Step 3: Important Security Note
+
+⚠️ **NEVER commit .env.notion to git!**
+
+The token grants access to your Notion workspace. Keep it secret:
+
+```bash
+# Make sure .env.notion is in .gitignore
+echo ".env.notion" >> .gitignore
+echo ".env" >> .gitignore
+```
+
+---
+
+## Getting Your NOTION_PARENT_PAGE
+
+This is the default page where new uploads will be created as child pages.
+
+### Step 1: Choose a Parent Page
+
+1. Open Notion
+2. Navigate to the page you want as the default parent
+3. This could be:
+   - A dedicated "Uploads" or "Articles" page
+   - Your main workspace page
+   - Any page where you want child pages created
+
+### Step 2: Get the Page ID from URL
+
+The Notion URL looks like:
+```
+https://www.notion.so/Page-Title-abc123def456789012345678901234
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                  This is the page ID
+```
+
+**Extract the ID**:
+- It's the long string of letters and numbers at the end
+- Can be 32 characters without dashes: `abc123def456789012345678901234`
+- Or UUID format with dashes: `abc12345-6789-0123-4567-890123456789`
+- Both formats work
+
+### Step 3: Add to Configuration
+
+```bash
+NOTION_PARENT_PAGE=abc123def456789012345678901234
+```
+
+### Step 4: Share Page with Integration
+
+**Critical**: The parent page must be shared with your integration!
+
+1. Open the parent page in Notion
+2. Click the "..." menu (top right)
+3. Scroll to bottom → "Add connections"
+4. Find and select your integration name
+5. Click "Confirm"
+
+**Without this step**: You'll get "404 object_not_found" errors when uploading.
+
+---
+
+## Is NOTION_PARENT_PAGE Required?
+
+**Short answer**: No, but highly recommended.
+
+**Without NOTION_PARENT_PAGE**:
+- You MUST specify destination with every upload:
+  - `--parent-id PAGE_ID` or
+  - `--database-id DB_ID` or
+  - `--page-id PAGE_ID` (for appends)
+- Script will show error if you don't specify destination
+
+**With NOTION_PARENT_PAGE**:
+- Can upload without flags: `python3 scripts/notion_upload.py article.md`
+- Destination defaults to your configured parent page
+- Can still override with flags when needed
+
+---
+
+## Verifying Configuration
+
+### Test NOTION_TOKEN
+
+```bash
+# Try downloading any page you have access to
+python3 scripts/notion_download.py YOUR_PAGE_ID
+```
+
+**Success**: If it downloads, token is correct.
+**Error "NOTION_TOKEN not found"**: Token not configured properly.
+**Error "401 Unauthorized"**: Token is invalid.
+
+### Test NOTION_PARENT_PAGE
+
+```bash
+# Try uploading a test file
+echo "# Test" > test.md
+python3 scripts/notion_upload.py test.md
+```
+
+**Success**: Page created at default parent.
+**Error "No parent page specified..."**: NOTION_PARENT_PAGE not configured.
+**Error "404 object_not_found"**: Parent page not shared with integration.
+
+---
+
+## Troubleshooting
+
+**"NOTION_TOKEN not found"**:
+- Check `.env.notion` exists in current or parent directory
+- Check file format: `NOTION_TOKEN=ntn_...` (no quotes, no spaces around `=`)
+- Check environment variable: `echo $NOTION_TOKEN`
+
+**"NOTION_PARENT_PAGE not configured"**:
+- Add `NOTION_PARENT_PAGE=...` to `.env.notion`
+- OR use `--parent-id` flag explicitly
+
+**"404 object_not_found"**:
+- Page not shared with integration (see "Share Page" step above)
+- Invalid page ID
+- Page was deleted
+
+**Script can't find .env.notion**:
+- Check you're in the right directory
+- Check file name is exactly `.env.notion` (with the dot)
+- Try absolute path for testing: `NOTION_TOKEN=$(cat /full/path/to/.env.notion | grep NOTION_TOKEN | cut -d= -f2)`
+
+---
+
+## Example .env.notion File
+
+```bash
+# Notion Configuration
+# Created: 2025-01-18
+
+# Integration token (required)
+# Get from: https://www.notion.so/my-integrations
+NOTION_TOKEN=ntn_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP
+
+# Default parent page for uploads (optional but recommended)
+# This is the page ID where new pages will be created as children
+# Get from your Notion page URL
+NOTION_PARENT_PAGE=abc123def456789012345678901234
+
+# Notes:
+# - Never commit this file to git!
+# - Add to .gitignore
+# - Keep token secret
+# - Share parent page with integration in Notion
+```
+
+---
+
+## Next Steps
+
+After configuration:
+
+1. **Test**: Try a simple upload/download
+2. **Share pages**: Remember to share any page you want to access
+3. **Organize**: Create a good default parent page structure
+4. **Backup**: Keep a copy of your configuration (securely!)
+
+For complete first-time setup walkthrough, load: `guides/setup/first-time-setup.md`

--- a/guides/setup/first-time-setup.md
+++ b/guides/setup/first-time-setup.md
@@ -1,0 +1,299 @@
+---
+**PDA Tier**: 3 (Setup Guide)
+**Estimated Tokens**: ~600 tokens
+**Load Condition**: User explicitly asks for complete setup walkthrough
+**Dependencies**: References configuration-guide.md for details
+---
+
+# First-Time Setup Guide
+
+## Token Budget
+
+**This Guide**: ~600 tokens
+**Total with Tier 1+2**: 1,350 tokens
+
+---
+
+## Complete Setup Walkthrough
+
+### Prerequisites
+
+- Python 3.8 or higher installed
+- Notion account
+- pip (Python package manager)
+
+---
+
+## Step 1: Install Python Dependencies
+
+```bash
+# Navigate to the skill directory
+cd /Users/richardhightower/.claude/skills/notion-uploader-downloader
+
+# Install required packages
+pip install -r scripts/requirements.txt
+```
+
+**Packages installed**:
+- `requests` - HTTP library for Notion API calls
+- `python-dotenv` - For loading .env files
+
+---
+
+## Step 2: Create Notion Integration
+
+1. **Go to Notion integrations page**:
+   - Visit: https://www.notion.so/my-integrations
+   - Click "+ New integration"
+
+2. **Configure integration**:
+   - **Name**: "Markdown Uploader" (or your preferred name)
+   - **Associated workspace**: Select your workspace
+   - **Type**: Internal integration
+   - Click "Submit"
+
+3. **Copy integration token**:
+   - After creation, find "Internal Integration Token"
+   - Click "Show" → "Copy"
+   - Save this token (you'll need it in Step 4)
+
+---
+
+## Step 3: Choose and Prepare Parent Page
+
+1. **Create or choose a parent page**:
+   - Open Notion
+   - Create a new page called "Uploaded Articles" (or use existing page)
+   - This is where uploaded markdown files will be created as child pages
+
+2. **Get the page ID**:
+   - Open the page in your browser
+   - Copy the URL
+   - Extract the ID from URL (long string at the end)
+   - Example: `https://notion.so/Uploads-abc123def456` → ID is `abc123def456`
+
+3. **Share page with integration**:
+   - Open the page
+   - Click "..." menu (top right)
+   - Scroll to "Add connections"
+   - Select your integration name ("Markdown Uploader")
+   - Click "Confirm"
+
+**Critical**: Without sharing, you'll get "404 object_not_found" errors.
+
+---
+
+## Step 4: Create .env.notion Configuration File
+
+```bash
+# In the skill directory (or your project directory)
+cd /Users/richardhightower/.claude/skills/notion-uploader-downloader
+
+# Create .env.notion file
+touch .env.notion
+
+# Edit the file (use nano, vim, or any text editor)
+nano .env.notion
+```
+
+**Add this content** (replace with your actual values):
+
+```bash
+NOTION_TOKEN=ntn_paste_your_token_here
+NOTION_PARENT_PAGE=paste_your_page_id_here
+```
+
+**Example**:
+```bash
+NOTION_TOKEN=ntn_1234567890abcdefghijklmnopqrstuvwxyz1234567890
+NOTION_PARENT_PAGE=abc123def456789012345678901234
+```
+
+Save and exit.
+
+---
+
+## Step 5: Secure the Configuration File
+
+⚠️ **Important**: Never commit .env.notion to git!
+
+```bash
+# Add to .gitignore
+echo ".env.notion" >> .gitignore
+echo ".env" >> .gitignore
+
+# Verify it's ignored
+git status  # Should not show .env.notion
+```
+
+---
+
+## Step 6: Test the Setup
+
+### Test 1: Create a test markdown file
+
+```bash
+cat > test-upload.md <<EOF
+# Test Article
+
+This is a test article to verify the Notion uploader works.
+
+## Features
+
+- Markdown to Notion conversion
+- Image upload support
+- Rich formatting
+
+**Success!** If you can read this in Notion, the setup works.
+EOF
+```
+
+### Test 2: Upload to Notion
+
+```bash
+python3 scripts/notion_upload.py test-upload.md
+```
+
+**Expected output**:
+```
+✅ Page created successfully!
+   Page ID: xyz123...
+   URL: https://notion.so/Test-Article-xyz123...
+```
+
+### Test 3: Open in Notion
+
+- Click the URL from the output
+- Verify the page appears in Notion
+- Check it's a child of your parent page
+- Verify formatting is preserved
+
+### Test 4: Download back
+
+```bash
+python3 scripts/notion_download.py xyz123  # Use the page ID from step 2
+```
+
+**Expected**:
+- Creates `./downloaded/test-article.md`
+- Content matches original
+
+---
+
+## Step 7: Organize Your Workspace
+
+### Create a good structure in Notion
+
+1. **Main parent page**: "Uploaded Content" or "Articles"
+2. **Sub-pages by category** (optional):
+   - Blog Posts
+   - Documentation
+   - Notes
+   - etc.
+
+### Configure different parent pages for different projects
+
+You can have multiple `.env.notion` files in different directories:
+
+```
+~/projects/blog/.env.notion         → NOTION_PARENT_PAGE=blog_page_id
+~/projects/docs/.env.notion         → NOTION_PARENT_PAGE=docs_page_id
+~/projects/notes/.env.notion        → NOTION_PARENT_PAGE=notes_page_id
+```
+
+Each project directory will use its own parent page!
+
+---
+
+## Common First-Time Issues
+
+### Issue: "NOTION_TOKEN not found"
+
+**Solutions**:
+- Check .env.notion exists: `ls -la .env.notion`
+- Check format: `cat .env.notion` (should show `NOTION_TOKEN=ntn_...`)
+- Check no extra spaces: Should be `NOTION_TOKEN=value` not `NOTION_TOKEN = value`
+
+### Issue: "404 object_not_found"
+
+**Solutions**:
+- Share parent page with integration (Step 3.3 above)
+- Verify page ID is correct
+- Check page wasn't deleted
+
+### Issue: "Permission denied" or "Unauthorized"
+
+**Solutions**:
+- Token might be incorrect - copy again from Notion integrations page
+- Token might be expired - regenerate in Notion
+- Integration might not have access to workspace
+
+### Issue: Python or pip not found
+
+**Solutions**:
+```bash
+# Install Python 3 (macOS with Homebrew)
+brew install python3
+
+# Install Python 3 (Ubuntu/Debian)
+sudo apt-get install python3 python3-pip
+
+# Verify installation
+python3 --version
+pip3 --version
+```
+
+---
+
+## You're All Set!
+
+Now you can:
+
+- ✅ Upload markdown files to Notion
+- ✅ Download Notion pages to markdown
+- ✅ Append content to existing pages
+- ✅ Upload images automatically
+- ✅ Preserve rich formatting
+
+### Next Steps
+
+**Learn the workflows**:
+- `guides/workflows/upload-workflow.md` - Upload details
+- `guides/workflows/download-workflow.md` - Download details
+- `guides/workflows/update-workflow.md` - Append content
+
+**Explore features**:
+- `references/MAPPINGS.md` - All supported markdown elements
+- `references/QUICK_START.md` - Command quick reference
+
+**If you encounter errors**:
+- `guides/troubleshooting/error-resolution.md` - Common errors and fixes
+
+---
+
+## Quick Reference Card
+
+### Upload
+```bash
+python3 scripts/notion_upload.py article.md
+python3 scripts/notion_upload.py article.md --parent-id PAGE_ID
+```
+
+### Download
+```bash
+python3 scripts/notion_download.py PAGE_ID
+python3 scripts/notion_download.py "https://notion.so/Page-URL"
+```
+
+### Append/Update
+```bash
+python3 scripts/notion_upload.py new-content.md --page-id PAGE_ID
+```
+
+### Configuration Files
+- `.env.notion` - Main configuration
+- Add to `.gitignore` - CRITICAL for security
+
+### Getting Help
+- Configuration details: `guides/setup/configuration-guide.md`
+- Troubleshooting: `guides/troubleshooting/error-resolution.md`

--- a/guides/troubleshooting/error-resolution.md
+++ b/guides/troubleshooting/error-resolution.md
@@ -1,0 +1,464 @@
+---
+**PDA Tier**: 3 (Troubleshooting Guide)
+**Estimated Tokens**: ~950 tokens
+**Load Condition**: Errors occur or user reports issues
+**Dependencies**: May route to configuration-guide.md
+---
+
+# Error Resolution Guide
+
+## Token Budget
+
+**This Guide**: ~950 tokens
+**Total with Tier 1+2**: 1,700 tokens
+
+---
+
+## Error Category Index
+
+Jump to specific error:
+- [Configuration Errors](#configuration-errors)
+- [Permission & Access Errors](#permission--access-errors)
+- [Image Upload Errors](#image-upload-errors)
+- [Script Execution Errors](#script-execution-errors)
+- [Notion API Errors](#notion-api-errors)
+
+---
+
+## Configuration Errors
+
+### Error: "NOTION_TOKEN not found!"
+
+**Full message**:
+```
+❌ NOTION_TOKEN not found!
+   Create .env.notion with NOTION_TOKEN=your_token
+   Or set NOTION_TOKEN environment variable
+```
+
+**Cause**: Notion integration token not configured.
+
+**Solutions**:
+
+1. **Create .env.notion file**:
+   ```bash
+   echo "NOTION_TOKEN=ntn_your_token_here" > .env.notion
+   ```
+
+2. **Or set environment variable**:
+   ```bash
+   export NOTION_TOKEN=ntn_your_token_here
+   ```
+
+3. **Verify file exists**:
+   ```bash
+   ls -la .env.notion
+   cat .env.notion  # Should show NOTION_TOKEN=...
+   ```
+
+**Get your token**: https://www.notion.so/my-integrations
+
+**Route to**: `guides/setup/configuration-guide.md` for complete setup
+
+---
+
+### Error: "No parent page specified and NOTION_PARENT_PAGE not configured"
+
+**Full message**:
+```
+❌ No parent page specified and NOTION_PARENT_PAGE not configured
+
+   Please either:
+   1. Add NOTION_PARENT_PAGE=your_page_id to .env.notion file
+   2. Set NOTION_PARENT_PAGE environment variable
+   3. Use --parent-id, --database-id, or --page-id flag
+```
+
+**Cause**: No destination specified for upload and no default configured.
+
+**Solutions**:
+
+1. **Add to .env.notion** (recommended):
+   ```bash
+   echo "NOTION_PARENT_PAGE=your_page_id" >> .env.notion
+   ```
+
+2. **Or use flag every time**:
+   ```bash
+   python3 scripts/notion_upload.py file.md --parent-id PAGE_ID
+   ```
+
+3. **Get page ID from Notion URL**:
+   - URL: `https://notion.so/My-Page-abc123def456`
+   - ID: `abc123def456`
+
+**Route to**: `guides/setup/configuration-guide.md` for details
+
+---
+
+## Permission & Access Errors
+
+### Error: "404 object_not_found" or "Could not find page"
+
+**HTTP response**:
+```json
+{
+  "object": "error",
+  "status": 404,
+  "code": "object_not_found",
+  "message": "Could not find page with ID: abc123..."
+}
+```
+
+**Causes** (in order of likelihood):
+
+1. **Page not shared with integration** (MOST COMMON)
+2. Invalid page ID
+3. Page was deleted or moved to trash
+4. Integration doesn't have access to workspace
+
+**Solutions**:
+
+#### Solution 1: Share Page with Integration
+
+1. Open the page in Notion
+2. Click "..." menu (top right)
+3. Scroll down to "Add connections"
+4. Find your integration name
+5. Click to add connection
+6. Click "Confirm"
+
+**This must be done for**:
+- The parent page (for uploads)
+- Any page you want to download
+- Any database you want to create entries in
+
+#### Solution 2: Verify Page ID
+
+```bash
+# Try accessing the page directly in browser
+https://notion.so/YOUR_PAGE_ID
+
+# If it doesn't open, ID is wrong
+```
+
+**Get correct ID**:
+- Open page in Notion → Copy URL → Extract ID from end
+
+#### Solution 3: Check Page Wasn't Deleted
+
+- Look in Notion trash (sidebar → "Trash")
+- If found, restore the page
+- Then share with integration
+
+---
+
+### Error: "401 Unauthorized"
+
+**HTTP response**:
+```json
+{
+  "object": "error",
+  "status": 401,
+  "code": "unauthorized",
+  "message": "API token is invalid."
+}
+```
+
+**Causes**:
+
+1. Token is incorrect or corrupted
+2. Token was regenerated in Notion (old token invalid)
+3. Integration was deleted
+
+**Solutions**:
+
+1. **Get fresh token**:
+   - Go to https://www.notion.so/my-integrations
+   - Find your integration
+   - Click "Show" → "Copy" for token
+   - Update .env.notion with new token
+
+2. **Verify token format**:
+   - Should start with `ntn_`
+   - Very long string (80+ characters)
+   - No spaces, no line breaks
+
+3. **Check integration exists**:
+   - Visit integrations page
+   - Verify your integration is still there
+   - If deleted, create new one
+
+---
+
+## Image Upload Errors
+
+### Error: "Failed to upload image: [filename]"
+
+**Causes**:
+
+1. Image file doesn't exist
+2. Image path is wrong (relative vs. absolute)
+3. Image size exceeds 20MB limit
+4. Image format not supported
+5. Network/connectivity issue
+
+**Solutions**:
+
+#### Solution 1: Verify Image Exists
+
+```bash
+# Check if image file exists
+ls -lh path/to/image.png
+
+# Verify it's accessible
+file path/to/image.png
+```
+
+#### Solution 2: Fix Image Path
+
+**In markdown**, image paths should be:
+
+```markdown
+<!-- Relative to markdown file (RECOMMENDED) -->
+![alt text](./images/photo.png)
+![alt text](images/photo.png)
+
+<!-- Absolute path (works but not portable) -->
+![alt text](/full/path/to/image.png)
+```
+
+**Script resolves paths relative to markdown file location**:
+- If markdown is in `/home/user/docs/article.md`
+- And markdown has `![](images/pic.png)`
+- Script looks for `/home/user/docs/images/pic.png`
+
+#### Solution 3: Check Image Size
+
+```bash
+# Check file size
+ls -lh image.png
+
+# If over 20MB, resize/compress first
+# Use ImageMagick, Photoshop, or online tools
+```
+
+**Notion limit**: 20MB per image file
+
+#### Solution 4: Verify Format
+
+**Supported formats**:
+- PNG
+- JPG/JPEG
+- GIF
+- SVG (may have rendering issues)
+- WebP
+
+**Not supported**:
+- PSD
+- AI
+- RAW formats
+- Most video formats as images
+
+---
+
+## Script Execution Errors
+
+### Error: "python3: command not found"
+
+**Cause**: Python 3 not installed or not in PATH.
+
+**Solutions**:
+
+```bash
+# macOS (with Homebrew)
+brew install python3
+
+# Ubuntu/Debian
+sudo apt-get install python3
+
+# Verify installation
+python3 --version  # Should show 3.8 or higher
+```
+
+---
+
+### Error: "ModuleNotFoundError: No module named 'requests'"
+
+**Cause**: Required Python packages not installed.
+
+**Solution**:
+
+```bash
+# Install dependencies
+pip install -r scripts/requirements.txt
+
+# Or install individually
+pip install requests python-dotenv
+```
+
+---
+
+### Error: "Permission denied" when creating files
+
+**Cause**: No write permissions for output directory.
+
+**Solutions**:
+
+```bash
+# Check permissions
+ls -ld ./downloaded
+
+# Create directory with correct permissions
+mkdir -p ./downloaded
+chmod 755 ./downloaded
+
+# Or download to a different location
+python3 scripts/notion_download.py PAGE_ID --output ~/Documents/notion-downloads
+```
+
+---
+
+## Notion API Errors
+
+### Error: "400 validation_error"
+
+**Example**:
+```json
+{
+  "object": "error",
+  "status": 400,
+  "code": "validation_error",
+  "message": "body failed validation..."
+}
+```
+
+**Causes**:
+
+1. Invalid block structure sent to Notion
+2. Unsupported property type
+3. Malformed request
+
+**Solutions**:
+
+1. **Check your markdown**:
+   - Verify it's valid markdown
+   - Check for weird characters
+   - Try with simpler markdown first
+
+2. **Report as bug** (if markdown seems valid):
+   - This might be a parser issue
+   - Save the problematic markdown
+   - Test with minimal example to isolate issue
+
+---
+
+### Error: "429 rate_limited"
+
+**Message**: "Rate limited. Too many requests."
+
+**Cause**: Exceeded Notion API rate limits.
+
+**Notion limits**:
+- 3 requests per second per integration
+
+**Solutions**:
+
+1. **Wait a minute** then retry
+2. **Don't upload too many files rapidly** in a loop
+3. **Add delay between uploads**:
+   ```bash
+   python3 scripts/notion_upload.py file1.md
+   sleep 2
+   python3 scripts/notion_upload.py file2.md
+   sleep 2
+   python3 scripts/notion_upload.py file3.md
+   ```
+
+---
+
+### Error: "503 service_unavailable"
+
+**Message**: "Service temporarily unavailable"
+
+**Cause**: Notion's servers are down or experiencing issues.
+
+**Solutions**:
+
+1. **Wait and retry** (5-10 minutes)
+2. **Check Notion status**: https://status.notion.so/
+3. **Try again later** if widespread outage
+
+---
+
+## Debugging Techniques
+
+### Enable Verbose Output
+
+Add `print()` statements in script for debugging:
+
+```python
+# Add to scripts/notion_upload.py temporarily
+print(f"DEBUG: Token found: {token[:10]}...")
+print(f"DEBUG: Parent page: {args.parent_id}")
+print(f"DEBUG: Blocks to upload: {len(blocks)}")
+```
+
+### Check Network Connectivity
+
+```bash
+# Test connection to Notion API
+curl -I https://api.notion.com/v1/users/me \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
+  -H "Notion-Version: 2022-06-28"
+
+# Should return 200 OK if token valid
+```
+
+### Validate JSON Responses
+
+If script fails, capture the API response:
+
+```python
+# Add to script
+print("Response:", response.text)
+print("Status:", response.status_code)
+```
+
+---
+
+## Getting More Help
+
+### Check Documentation
+
+- **Configuration**: `guides/setup/configuration-guide.md`
+- **First-time setup**: `guides/setup/first-time-setup.md`
+- **Upload workflow**: `guides/workflows/upload-workflow.md`
+- **Download workflow**: `guides/workflows/download-workflow.md`
+
+### Common Patterns
+
+**Most errors are**:
+1. Configuration missing (token or parent page)
+2. Page not shared with integration
+3. Wrong path to file or image
+
+**Quick checklist**:
+- [ ] .env.notion exists and has NOTION_TOKEN
+- [ ] Integration created in Notion
+- [ ] Pages shared with integration
+- [ ] File paths are correct
+- [ ] Python dependencies installed
+
+---
+
+## Error Not Listed?
+
+If you encounter an error not covered here:
+
+1. **Read the error message carefully** - it often tells you what's wrong
+2. **Check Notion status page** - might be a platform issue
+3. **Test with minimal example** - isolate the problem
+4. **Check the script output** - look for specific error details
+
+**Most issues are configuration or permissions** - double-check those first!

--- a/guides/workflows/download-workflow.md
+++ b/guides/workflows/download-workflow.md
@@ -1,0 +1,229 @@
+---
+**PDA Tier**: 3 (Workflow Guide)
+**Estimated Tokens**: ~850 tokens
+**Load Condition**: Download Intent - User wants to extract content from Notion
+**Dependencies**: May load error-resolution.md
+---
+
+# Download Workflow Guide
+
+## Token Budget for This Workflow
+
+**Tier 1 (Metadata)**: 150 tokens *(already loaded)*
+**Tier 2 (Orchestrator)**: 600 tokens *(already loaded)*
+**Tier 3 (This Guide)**: 850 tokens *(loading now)*
+
+**Conditional Loading** (if needed):
+- `guides/troubleshooting/error-resolution.md`: +950 tokens (if errors occur)
+
+**Estimated Total**: 1,600-2,550 tokens
+**Status**: ✅ Within budget (10,000 token limit)
+
+---
+
+## Workflow Overview
+
+**Purpose**: Download a Notion page (with images) to markdown format.
+
+**Input**: Notion page ID or URL
+**Output**: Markdown file with images in `./downloaded/` directory
+**Prerequisites**: NOTION_TOKEN configured, valid page ID
+
+---
+
+## Step 1: Extract Page ID
+
+Users can provide the page ID in multiple formats:
+
+### Format 1: Notion URL
+```
+https://notion.so/Page-Title-abc123def456
+https://notion.so/abc123def456
+https://www.notion.so/workspace/Page-Title-abc123def456
+```
+
+**Script handles**: Extracts the 32-character hex ID from any Notion URL format.
+
+### Format 2: Page ID (32-character hex)
+```
+abc123def456789...
+```
+
+### Format 3: Page ID (UUID format with hyphens)
+```
+abc12345-6789-0123-4567-890123456789
+```
+
+**All formats work**: The script automatically extracts and formats the ID correctly.
+
+---
+
+## Step 2: Determine Output Location
+
+### Option A: Default Location (Recommended)
+**Command**:
+```bash
+python3 scripts/notion_download.py PAGE_ID
+```
+
+**Output**:
+- Creates `./downloaded/` directory if it doesn't exist
+- Saves markdown file as `./downloaded/page-title.md`
+- Downloads images to `./downloaded/images/`
+
+### Option B: Custom Output Directory
+**Command**:
+```bash
+python3 scripts/notion_download.py PAGE_ID --output custom/path
+```
+
+**Output**:
+- Creates `custom/path/` directory if needed
+- Saves markdown as `custom/path/page-title.md`
+- Downloads images to `custom/path/images/`
+
+---
+
+## Step 3: Execute Download
+
+**Command structure**:
+```bash
+python3 scripts/notion_download.py <PAGE_ID_OR_URL> [--output DIR]
+```
+
+**Example commands**:
+```bash
+# Download with default output
+python3 scripts/notion_download.py abc123def456
+
+# Download from URL
+python3 scripts/notion_download.py "https://notion.so/My-Page-abc123"
+
+# Custom output directory
+python3 scripts/notion_download.py abc123def456 --output ./my-backups
+
+# Download multiple pages (run separately)
+python3 scripts/notion_download.py page1_id
+python3 scripts/notion_download.py page2_id
+python3 scripts/notion_download.py page3_id
+```
+
+---
+
+## Step 4: Monitor Execution
+
+**Script output shows**:
+- Fetching page from Notion
+- Downloading images (if any): "Downloading image: image_name.png"
+- Converting blocks to markdown
+- Saving file
+
+**Expected output**:
+```
+✅ Page downloaded successfully!
+   Saved to: ./downloaded/my-page-title.md
+   Images: 3 images downloaded to ./downloaded/images/
+```
+
+---
+
+## Step 5: Verify Downloaded Content
+
+**Check that**:
+1. Markdown file created at expected location
+2. Images directory created (if page had images)
+3. Images referenced in markdown match downloaded files
+4. Formatting preserved (headers, lists, code blocks, etc.)
+
+**Report to user**:
+- ✅ File path where markdown was saved
+- ✅ Number of images downloaded
+- ✅ Confirm download was successful
+
+---
+
+## Downloaded Content Format
+
+**Markdown file includes**:
+- Page title as H1 heading
+- All page content converted to markdown
+- Images as `![alt](./images/filename.png)` references
+- All formatting preserved: bold, italic, code, links, etc.
+- Tables, lists, code blocks maintained
+- Nested lists supported
+
+**Image handling**:
+- All images downloaded to `./downloaded/images/` (or `<output>/images/`)
+- Filenames sanitized for filesystem compatibility
+- Image URLs replaced with local relative paths
+- Original image format preserved (PNG, JPG, GIF, etc.)
+
+---
+
+## Error Handling
+
+### Common Errors
+
+**"NOTION_TOKEN not found"**:
+- Route to: `guides/setup/configuration-guide.md` (+700 tokens)
+- User needs to configure .env.notion file
+
+**"404 object_not_found" or "Could not find page"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- Common causes:
+  - Invalid page ID
+  - Page not shared with Notion integration
+  - Page was deleted
+
+**"Failed to download image"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- Image URLs may be expired or inaccessible
+- Download continues, image reference left as-is in markdown
+
+**"Permission denied" or file system errors**:
+- Check output directory permissions
+- Verify disk space available
+- Ensure directory is writable
+
+---
+
+## Round-Trip Compatibility
+
+**Download → Edit → Upload workflow**:
+
+1. Download page: `python3 scripts/notion_download.py PAGE_ID`
+2. Edit the markdown file locally
+3. Upload back to Notion: `python3 scripts/notion_upload.py ./downloaded/page-title.md --parent-id PARENT`
+
+**Formatting preservation**:
+- Most elements survive round-trip (download → upload)
+- Some Notion-specific features may not convert perfectly
+- Always verify uploaded content matches expectations
+
+---
+
+## When to Load Additional Resources
+
+**User asks "What elements are preserved?" or "What's supported?"**:
+→ Load `references/MAPPINGS.md` (+515 tokens)
+
+**User asks "Show me command examples"**:
+→ Load `references/QUICK_START.md` (+320 tokens)
+
+**Any error occurs during execution**:
+→ Load `guides/troubleshooting/error-resolution.md` (+950 tokens)
+
+---
+
+## Post-Execution Token Summary
+
+**Tokens used this request**:
+- Tier 1: 150
+- Tier 2: 600
+- This guide: 850
+- Conditionally loaded: 0-950 (if errors occur)
+- **Total**: 1,600-2,550 tokens
+
+**Remaining budget**: 7,450-8,400 tokens
+
+**Status**: ✅ Well within 10,000 token budget

--- a/guides/workflows/recursive-download-workflow.md
+++ b/guides/workflows/recursive-download-workflow.md
@@ -1,0 +1,282 @@
+---
+**PDA Tier**: 3 (Workflow Guide)
+**Estimated Tokens**: ~1,100 tokens
+**Load Condition**: Recursive Download Intent - User wants to download a page AND all child pages
+**Dependencies**: May load error-resolution.md
+---
+
+# Recursive Download Workflow Guide
+
+## Token Budget for This Workflow
+
+**Tier 1 (Metadata)**: 150 tokens *(already loaded)*
+**Tier 2 (Orchestrator)**: 600 tokens *(already loaded)*
+**Tier 3 (This Guide)**: 1,100 tokens *(loading now)*
+
+**Conditional Loading** (if needed):
+- `guides/troubleshooting/error-resolution.md`: +950 tokens (if errors occur)
+
+**Estimated Total**: 1,850-2,800 tokens
+**Status**: ✅ Within budget (10,000 token limit)
+
+---
+
+## Workflow Overview
+
+**Purpose**: Download a Notion page and ALL its child pages recursively, creating a folder structure matching the Notion hierarchy.
+
+**Key Features**:
+- Two-phase processing (discovery → download)
+- YAML frontmatter with metadata (notion_id, title, timestamps)
+- Strict file naming (lowercase, underscores, no special chars)
+- mapping.json for future round-trip uploads
+- Dry-run mode for preview
+- Flat mode option
+
+**Input**: Notion page ID or URL
+**Output**: Folder structure with markdown files, images, and mapping.json
+
+---
+
+## Step 1: Extract Page ID
+
+Same as single-page download - accepts:
+- Notion URL: `https://notion.so/Page-Title-abc123def456`
+- Page ID (32-char hex): `abc123def456789...`
+- UUID format: `abc12345-6789-0123-4567-890123456789`
+
+---
+
+## Step 2: Choose Mode and Options
+
+### Basic Recursive Download
+```bash
+python3 scripts/notion_download_recursive.py PAGE_ID --output ./docs/
+```
+
+### Dry Run (Preview Structure)
+```bash
+python3 scripts/notion_download_recursive.py PAGE_ID --dry-run
+```
+
+### Flat Mode (No Subdirectories)
+```bash
+python3 scripts/notion_download_recursive.py PAGE_ID --flat --output ./flat_docs/
+```
+
+### Limited Depth
+```bash
+python3 scripts/notion_download_recursive.py PAGE_ID --max-depth 2 --output ./docs/
+```
+
+### Verbose Output
+```bash
+python3 scripts/notion_download_recursive.py PAGE_ID --verbose --output ./docs/
+```
+
+---
+
+## Step 3: Understand Output Structure
+
+### Hierarchical Mode (Default)
+
+```
+output/
+├── parent_page/
+│   ├── index.md              # Parent page content
+│   ├── child_page_1.md       # Leaf child (no children)
+│   └── child_page_2/         # Child with grandchildren
+│       ├── index.md
+│       └── grandchild.md
+├── images/
+│   ├── parent_page/
+│   │   └── parent_page_image_01.png
+│   └── child_page_1/
+│       └── child_page_1_image_01.png
+└── mapping.json              # Page ID mappings for uploads
+```
+
+### Flat Mode
+
+```
+output/
+├── parent_page.md
+├── 01_child_page_1.md        # Depth-prefixed
+├── 01_child_page_2.md
+├── 02_grandchild.md
+├── images/
+│   └── (organized by page name)
+└── mapping.json
+```
+
+---
+
+## Step 4: File Naming Convention
+
+All files use strict naming:
+
+| Notion Title | Local Filename |
+|-------------|----------------|
+| "Design Overview" | `design_overview.md` |
+| "API Reference (v2)" | `api_reference_v2.md` |
+| "Chapter 1: Introduction" | `chapter_1_introduction.md` |
+| "My Page!!!" | `my_page.md` |
+
+**Rules Applied**:
+- Lowercase all characters
+- Replace spaces/hyphens with underscores
+- Remove special characters
+- Collapse multiple underscores
+- Trim leading/trailing underscores
+
+---
+
+## Step 5: YAML Frontmatter
+
+Each downloaded markdown file includes frontmatter:
+
+```yaml
+---
+notion_id: 2c2d6bbd-bbea-8156-aefd-ed7fdd75c086
+notion_url: https://notion.so/2c2d6bbdbbea8156aefded7fdd75c086
+title: Design Overview
+parent_id: 1a2b3c4d-5e6f-7890-abcd-ef1234567890
+created_time: 2025-01-15T10:30:00.000Z
+last_edited_time: 2025-12-06T14:22:00.000Z
+downloaded_at: 2025-12-06T22:30:00
+has_children: true
+---
+
+# Design Overview
+
+Content starts here...
+```
+
+**Use Cases for Frontmatter**:
+- Re-upload to same Notion pages (update vs create)
+- Track which local files map to which Notion pages
+- Detect if content changed since last download
+- Build link references between pages
+
+---
+
+## Step 6: Mapping File (mapping.json)
+
+The mapping file enables round-trip sync:
+
+```json
+{
+  "source": {
+    "notion_id": "parent-page-id",
+    "title": "Documentation Root",
+    "url": "https://notion.so/..."
+  },
+  "downloaded_at": "2025-12-06T22:30:00",
+  "pages": {
+    "parent_page/index.md": {
+      "notion_id": "2c2d6bbd-...",
+      "title": "Parent Page",
+      "parent_id": null,
+      "has_children": true,
+      "child_paths": ["parent_page/child_1.md"]
+    }
+  },
+  "statistics": {
+    "total_pages": 15,
+    "total_images": 23,
+    "max_depth": 3
+  }
+}
+```
+
+---
+
+## Step 7: Round-Trip Sync Workflow
+
+### Download → Edit → Upload
+
+```bash
+# 1. Download entire documentation tree
+python3 scripts/notion_download_recursive.py PAGE_ID --output ./docs/
+
+# 2. Edit markdown files locally
+# (Uses any text editor or IDE)
+
+# 3. Upload back with preserved mappings
+python3 scripts/notion_upload.py ./docs/ --recursive --mapping-file ./docs/mapping.json
+```
+
+**Benefits**:
+- Updates existing pages instead of creating duplicates
+- Preserves page hierarchy and relationships
+- Maintains internal link references
+
+---
+
+## Error Handling
+
+### Common Errors
+
+**"NOTION_TOKEN not found"**:
+- Route to: `guides/setup/configuration-guide.md`
+
+**"404 object_not_found"**:
+- Page not shared with integration
+- Page ID is invalid or deleted
+- Route to: `guides/troubleshooting/error-resolution.md`
+
+**"Max depth exceeded"**:
+- Reduce --max-depth value
+- Very deep hierarchies may hit API limits
+
+**"Rate limiting" (HTTP 429)**:
+- Script handles automatically with backoff
+- Large hierarchies may take longer
+
+---
+
+## CLI Reference
+
+```
+usage: notion_download_recursive.py [-h] [--output DIR] [--max-depth N]
+                                    [--flat] [--no-images] [--dry-run]
+                                    [--verbose]
+                                    page_id
+
+Arguments:
+  page_id               Notion page ID or URL to download recursively
+
+Options:
+  --output, -o DIR      Output directory (default: ./downloaded/)
+  --max-depth N         Maximum recursion depth (default: unlimited)
+  --flat                Flatten hierarchy (no subdirectories)
+  --no-images           Skip downloading images
+  --dry-run             Show structure without downloading
+  --verbose, -v         Detailed progress output
+```
+
+---
+
+## When to Load Additional Resources
+
+**User asks about element support**:
+→ Load `references/MAPPINGS.md` (+515 tokens)
+
+**Any error occurs**:
+→ Load `guides/troubleshooting/error-resolution.md` (+950 tokens)
+
+**User asks about initial setup**:
+→ Load `guides/setup/configuration-guide.md` (+700 tokens)
+
+---
+
+## Post-Execution Token Summary
+
+**Tokens used this request**:
+- Tier 1: 150
+- Tier 2: 600
+- This guide: 1,100
+- Conditionally loaded: 0-950 (if errors)
+- **Total**: 1,850-2,800 tokens
+
+**Status**: ✅ Well within 10,000 token budget

--- a/guides/workflows/update-workflow.md
+++ b/guides/workflows/update-workflow.md
@@ -1,0 +1,286 @@
+---
+**PDA Tier**: 3 (Workflow Guide)
+**Estimated Tokens**: ~1,100 tokens
+**Load Condition**: Update/Append Intent - User wants to add content to existing Notion page
+**Dependencies**: May load QUICK_START.md, error-resolution.md
+---
+
+# Update/Append Workflow Guide
+
+## Token Budget for This Workflow
+
+**Tier 1 (Metadata)**: 150 tokens *(already loaded)*
+**Tier 2 (Orchestrator)**: 600 tokens *(already loaded)*
+**Tier 3 (This Guide)**: 1,100 tokens *(loading now)*
+
+**Conditional Loading** (if needed):
+- `references/QUICK_START.md`: +320 tokens (if command syntax unclear)
+- `guides/troubleshooting/error-resolution.md`: +950 tokens (if errors occur)
+
+**Estimated Total**: 1,850-3,120 tokens
+**Status**: ✅ Within budget (10,000 token limit)
+
+---
+
+## Workflow Overview
+
+**Purpose**: Append markdown content to an existing Notion page or database entry.
+
+**Input**: Markdown file + existing page ID
+**Output**: Updated Notion page with appended content
+**Prerequisites**: NOTION_TOKEN configured, valid page ID, page is shared with integration
+
+**Key Difference from Upload**: Uses `--page-id` flag and **appends** content (does not replace existing content).
+
+---
+
+## Step 1: Prerequisites Check
+
+### 1.1 Verify Markdown File
+```bash
+# User must provide a markdown file with new content to append
+```
+
+**If file doesn't exist**: Report error and ask user to verify path.
+
+### 1.2 Check for PlantUML Diagrams (CRITICAL!)
+
+**Same as upload workflow** - search markdown for:
+- ` ```puml ` or ` ```plantuml ` code blocks
+- `![](*.puml)` image references
+
+**If PlantUML content found**:
+1. ⚠️ **STOP and invoke PlantUML skill FIRST**
+2. Path: `/Users/richardhightower/.claude/skills/plantuml`
+3. Script: `python scripts/process_markdown_puml.py <file.md> --format png`
+4. **Use transformed file** (`*_with_images.md`) for append operation
+5. **Reason**: Notion doesn't natively render PlantUML
+
+### 1.3 Get Target Page ID
+
+User must provide the page ID of the existing page:
+- Can be Notion URL: `https://notion.so/Page-Title-abc123def456`
+- Can be page ID: `abc123def456`
+- Can be UUID format: `abc12345-6789-0123-4567-890123456789`
+
+**Verify page access**:
+- Page must be shared with the Notion integration
+- Otherwise will get "404 object_not_found" error
+
+---
+
+## Step 2: Execute Update/Append
+
+**Command structure**:
+```bash
+python3 scripts/notion_upload.py <markdown_file> --page-id <PAGE_ID> [--cover-image IMAGE]
+```
+
+**Example commands**:
+```bash
+# Append content to existing page
+python3 scripts/notion_upload.py new-content.md --page-id abc123def456
+
+# Append to page via URL
+python3 scripts/notion_upload.py update.md --page-id "https://notion.so/My-Page-abc123"
+
+# Append with cover image update
+python3 scripts/notion_upload.py content.md --page-id abc123 --cover-image new-cover.png
+```
+
+**What happens**:
+1. Script fetches the existing page to verify access
+2. Parses the new markdown file
+3. **Appends blocks to the END** of the existing page
+4. Does NOT modify or remove existing content
+5. Does NOT change the page title (keeps original)
+6. Images in new content are uploaded and added
+
+---
+
+## Step 3: Understand Append Behavior
+
+### Content is Added to the End
+
+**Original page content**:
+```
+# Original Title
+Original paragraph 1
+Original paragraph 2
+```
+
+**Append this content** (from `update.md`):
+```
+## New Section
+New paragraph 1
+New paragraph 2
+```
+
+**Result**:
+```
+# Original Title
+Original paragraph 1
+Original paragraph 2
+## New Section
+New paragraph 1
+New paragraph 2
+```
+
+### Title Handling
+
+**Important**: The H1 heading in the appended markdown is NOT used as the page title.
+
+- If your markdown has `# New Title`, it becomes a H1 **block** in the page content
+- The page title in Notion remains the original title
+- To change page title, you must do it manually in Notion
+
+### Cover Image Handling
+
+**With `--cover-image` flag**:
+- Updates/replaces the page's cover image
+- Use this if you want to change the cover when appending content
+
+**Without flag**:
+- Keeps existing cover image
+- Most common for simple content appends
+
+---
+
+## Step 4: Works with Database Entries Too
+
+**Appending to database entries**:
+
+```bash
+# Append content to a database entry (row)
+python3 scripts/notion_upload.py additional-info.md --page-id DATABASE_ENTRY_ID
+```
+
+**Same behavior**:
+- Appends content blocks to the database entry's page
+- Does NOT modify database properties (title, tags, dates, etc.)
+- Only adds content blocks
+
+**To modify database properties**: Must use Notion UI or API directly (not supported by this script).
+
+---
+
+## Step 5: Monitor Execution
+
+**Script output**:
+```
+✅ Content appended successfully!
+   Page ID: abc123def456
+   URL: https://notion.so/Page-Title-abc123def456
+```
+
+**Verify**:
+- Open the Notion URL
+- Scroll to the end of the page
+- Confirm new content is there
+- Existing content unchanged
+
+---
+
+## Use Cases for Update/Append
+
+### 1. Daily Journal Entry
+```bash
+# Append today's entry to ongoing journal page
+python3 scripts/notion_upload.py 2025-01-18-entry.md --page-id journal-page-id
+```
+
+### 2. Meeting Notes Accumulation
+```bash
+# Add new meeting notes to existing meeting log
+python3 scripts/notion_upload.py meeting-2025-01-18.md --page-id meetings-page-id
+```
+
+### 3. Documentation Updates
+```bash
+# Append new section to existing documentation
+python3 scripts/notion_upload.py new-api-section.md --page-id api-docs-id
+```
+
+### 4. Database Entry Details
+```bash
+# Add more details to a project database entry
+python3 scripts/notion_upload.py project-update.md --page-id project-entry-id
+```
+
+---
+
+## Error Handling
+
+### Common Errors
+
+**"404 object_not_found" or "Could not find page"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- **Most common cause**: Page not shared with Notion integration
+- **Solution**: Open page → "..." menu → "Add connections" → Select integration
+
+**"NOTION_TOKEN not found"**:
+- Route to: `guides/setup/configuration-guide.md` (+700 tokens)
+- User needs to configure .env.notion file
+
+**"Failed to upload image"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- Check image paths, file existence, size limits (<20MB)
+
+**"Page is archived" or similar**:
+- Page may be in trash or archived
+- Restore page in Notion first, then retry
+
+---
+
+## When to Load Additional Resources
+
+**User asks "What's the difference between upload and update?"**:
+→ Load `references/QUICK_START.md` (+320 tokens) for command comparison
+
+**User asks "What happens to the existing content?"**:
+→ Explain: Existing content is preserved, new content appended to end
+
+**Any error occurs during execution**:
+→ Load `guides/troubleshooting/error-resolution.md` (+950 tokens)
+
+---
+
+## Important Notes
+
+### This is Append-Only
+
+**Cannot**:
+- ❌ Replace existing content
+- ❌ Insert content in the middle
+- ❌ Delete existing blocks
+- ❌ Modify page title (via script)
+- ❌ Update database properties
+
+**Can**:
+- ✅ Add new content to the end
+- ✅ Upload images with new content
+- ✅ Update cover image (via --cover-image flag)
+- ✅ Add all supported markdown elements
+
+### For Other Operations
+
+**To replace content**: Delete page and create new one with upload workflow
+
+**To edit content**: Use Notion UI directly or download → edit → delete old → upload new
+
+**To modify database properties**: Use Notion UI or Notion API directly
+
+---
+
+## Post-Execution Token Summary
+
+**Tokens used this request**:
+- Tier 1: 150
+- Tier 2: 600
+- This guide: 1,100
+- Conditionally loaded: 0-1,270 (depending on questions/errors)
+- **Total**: 1,850-3,120 tokens
+
+**Remaining budget**: 6,880-8,150 tokens
+
+**Status**: ✅ Well within 10,000 token budget

--- a/guides/workflows/upload-workflow.md
+++ b/guides/workflows/upload-workflow.md
@@ -1,0 +1,271 @@
+---
+**PDA Tier**: 3 (Workflow Guide)
+**Estimated Tokens**: ~1,250 tokens
+**Load Condition**: Upload Intent - User wants to send markdown to Notion
+**Dependencies**: May load MAPPINGS.md, QUICK_START.md, error-resolution.md
+---
+
+# Upload Workflow Guide
+
+## Token Budget for This Workflow
+
+**Tier 1 (Metadata)**: 150 tokens *(already loaded)*
+**Tier 2 (Orchestrator)**: 600 tokens *(already loaded)*
+**Tier 3 (This Guide)**: 1,250 tokens *(loading now)*
+
+**Conditional Loading** (if needed during execution):
+- `references/MAPPINGS.md`: +515 tokens (if user asks about supported elements)
+- `references/QUICK_START.md`: +320 tokens (if command syntax unclear)
+- `guides/troubleshooting/error-resolution.md`: +950 tokens (if errors occur)
+
+**Estimated Total**: 2,000-3,635 tokens
+**Status**: ✅ Within budget (10,000 token limit)
+
+---
+
+## Workflow Overview
+
+**Purpose**: Upload a markdown file (with images and formatting) to create a new Notion page or database entry.
+
+**Input**: Markdown file path (.md file)
+**Output**: Notion page URL and page ID
+**Prerequisites**: NOTION_TOKEN configured, markdown file exists
+
+---
+
+## Step 1: Prerequisites Check
+
+### 1.1 Verify Markdown File
+```bash
+# User must provide a markdown file path
+# Verify file exists before proceeding
+```
+
+**If file doesn't exist**: Report error and ask user to verify path.
+
+### 1.2 Check for PlantUML Diagrams (CRITICAL!)
+
+**Search the markdown for**:
+- ` ```puml ` or ` ```plantuml ` code blocks
+- `![](*.puml)` image references
+
+**If PlantUML content found**:
+1. ⚠️ **STOP the upload workflow immediately**
+2. Invoke PlantUML skill FIRST:
+   - Path: `/Users/richardhightower/.claude/skills/plantuml`
+   - Script: `python scripts/process_markdown_puml.py <file.md> --format png`
+   - This creates `<filename>_with_images.md` with diagrams converted to PNG
+3. **Use the transformed file** (`*_with_images.md`) for the rest of this workflow
+4. **Reason**: Notion does not natively render PlantUML code blocks
+
+**If no PlantUML**: Continue with original markdown file.
+
+### 1.3 Verify Configuration
+
+Check if required configuration is available:
+
+**NOTION_TOKEN** (required):
+- Discovery order: ENV var → `.env.notion` → `.env` → Parent dirs
+- If not found: Route to `guides/setup/configuration-guide.md`
+
+**NOTION_PARENT_PAGE** (optional):
+- Discovery order: Same as token
+- If not found AND user didn't specify --parent-id/--database-id/--page-id:
+  - Script will prompt user with helpful error message
+  - Route to `guides/setup/configuration-guide.md`
+
+---
+
+## Step 2: Determine Upload Destination
+
+User can specify destination in three ways (mutually exclusive):
+
+### Option A: Use Default Parent Page (Most Common)
+**Command**:
+```bash
+python3 scripts/notion_upload.py article.md
+```
+
+**What happens**:
+- Script looks for NOTION_PARENT_PAGE in environment/config
+- If found: Creates page as child of that parent
+- If not found: Shows configuration error with helpful instructions
+
+**Use when**: User wants to use their configured default location.
+
+### Option B: Specific Parent Page
+**Command**:
+```bash
+python3 scripts/notion_upload.py article.md --parent-id PAGE_ID
+```
+
+**What happens**:
+- Creates page as child of specified parent page
+- Overrides NOTION_PARENT_PAGE environment variable
+- Parent page must be shared with Notion integration
+
+**Use when**: User wants to upload to a different parent than default.
+
+### Option C: Specific Database
+**Command**:
+```bash
+python3 scripts/notion_upload.py article.md --database-id DATABASE_ID
+```
+
+**What happens**:
+- Creates entry in specified database
+- Uses first H1 heading as database title property
+- Database must have "title" property and be shared with integration
+
+**Use when**: User wants to create a database entry (not a page).
+
+---
+
+## Step 3: Optional Cover Image
+
+User can add a cover image to the uploaded page:
+
+```bash
+python3 scripts/notion_upload.py article.md --parent-id PAGE_ID --cover-image path/to/image.png
+```
+
+**Cover image requirements**:
+- Path can be relative to markdown file or absolute
+- Supported formats: PNG, JPG, GIF, etc.
+- Maximum size: 20MB
+- Uploaded via Notion File Upload API
+
+---
+
+## Step 4: Execute Upload
+
+**Full command structure**:
+```bash
+python3 scripts/notion_upload.py <markdown_file> \
+  [--parent-id PAGE_ID | --database-id DB_ID] \
+  [--cover-image IMAGE_PATH]
+```
+
+**Example commands**:
+```bash
+# Use default parent from environment
+python3 scripts/notion_upload.py my-article.md
+
+# Specify parent page
+python3 scripts/notion_upload.py my-article.md --parent-id abc123
+
+# Upload to database
+python3 scripts/notion_upload.py my-article.md --database-id xyz789
+
+# With cover image
+python3 scripts/notion_upload.py my-article.md --cover-image cover.png
+```
+
+---
+
+## Step 5: Monitor Execution
+
+**Script output shows**:
+- Parsing markdown file
+- Uploading images (if any): "Uploading image: image.png"
+- Creating Notion page
+- Final Notion URL
+
+**Expected output**:
+```
+✅ Page created successfully!
+   Page ID: abc123def456
+   URL: https://notion.so/Page-Title-abc123def456
+```
+
+---
+
+## Step 6: Verify Success
+
+**Success criteria**:
+1. Script returns exit code 0
+2. Notion URL is displayed
+3. Page ID is displayed
+
+**Report to user**:
+- ✅ Share the Notion URL so they can open the page
+- ✅ Confirm the upload was successful
+- ✅ Mention any images that were uploaded
+
+---
+
+## Error Handling
+
+### Common Errors
+
+**"NOTION_TOKEN not found"**:
+- Route to: `guides/setup/configuration-guide.md` (+700 tokens)
+- User needs to configure .env.notion file
+
+**"No parent page specified and NOTION_PARENT_PAGE not configured"**:
+- Route to: `guides/setup/configuration-guide.md` (+700 tokens)
+- User needs to either set NOTION_PARENT_PAGE or use a flag
+
+**"404 object_not_found" or "Could not find page"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- Most common cause: Page not shared with Notion integration
+
+**"Failed to upload image"**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- Common causes: Image path wrong, file doesn't exist, >20MB size
+
+**Script crashes or Python error**:
+- Route to: `guides/troubleshooting/error-resolution.md` (+950 tokens)
+- May be missing dependencies, Python version issue, etc.
+
+---
+
+## When to Load Additional Resources
+
+**User asks "What markdown elements are supported?"**:
+→ Load `references/MAPPINGS.md` (+515 tokens)
+
+**User asks "What's the command syntax?" or "Show me examples"**:
+→ Load `references/QUICK_START.md` (+320 tokens)
+
+**User asks "How does image upload work?" or other technical questions**:
+→ Load `references/IMPLEMENTATION_SUMMARY.md` (+1,090 tokens)
+
+**Any error occurs during execution**:
+→ Load `guides/troubleshooting/error-resolution.md` (+950 tokens)
+
+---
+
+## Supported Markdown Features
+
+**Quick Reference** (for details, load `references/MAPPINGS.md`):
+
+**Inline Formatting**: **bold**, *italic*, `code`, [links](url), ~~strikethrough~~, <u>underline</u>
+
+**Block Elements**:
+- Headers (H1-H6)
+- Bullet lists, numbered lists, task lists
+- Code blocks with syntax highlighting
+- Tables
+- Images (local files uploaded, URLs referenced)
+- Blockquotes
+- GitHub-style callouts (`> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, etc.)
+- Horizontal dividers
+- Mermaid diagrams (preserved in code blocks)
+
+---
+
+## Post-Execution Token Summary
+
+After completing this workflow, calculate and optionally report:
+
+**Tokens used this request**:
+- Tier 1: 150
+- Tier 2: 600
+- This guide: 1,250
+- Conditionally loaded: 0-2,555 (depending on errors/questions)
+- **Total**: 2,000-4,555 tokens
+
+**Remaining budget**: 5,445-8,000 tokens
+
+**Status**: ✅ Well within 10,000 token budget

--- a/scripts/notion_download_recursive.py
+++ b/scripts/notion_download_recursive.py
@@ -1,0 +1,786 @@
+#!/usr/bin/env python3
+"""
+Recursive Notion page downloader.
+
+Downloads a Notion page and all its child pages recursively,
+creating a folder structure matching the Notion hierarchy.
+
+Features:
+- Two-phase processing: discovery then download
+- YAML frontmatter with page metadata (notion_id, title, etc.)
+- Strict file naming (lowercase, underscores, no special chars)
+- Mapping file for round-trip sync
+- Dry-run mode for preview
+- Flat mode option (no subdirectories)
+
+Usage:
+    python notion_download_recursive.py <page_id_or_url> --output ./docs/
+    python notion_download_recursive.py <page_id_or_url> --dry-run
+    python notion_download_recursive.py <page_id_or_url> --flat --output ./flat_docs/
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+import requests
+
+from notion_utils import (
+    find_notion_token,
+    extract_page_id,
+    format_page_id,
+    sanitize_filename_strict,
+    ensure_directory
+)
+
+
+NOTION_VERSION = "2022-06-28"
+DEFAULT_OUTPUT_DIR = "./downloaded"
+
+
+@dataclass
+class NotionPage:
+    """Represents a Notion page with metadata."""
+    id: str
+    title: str
+    parent_id: Optional[str]
+    url: str
+    created_time: str
+    last_edited_time: str
+    has_children: bool
+    children: List['NotionPage'] = field(default_factory=list)
+    local_path: Optional[Path] = None
+    depth: int = 0
+
+
+class PageHierarchy:
+    """Discovers and builds page hierarchy from Notion."""
+
+    def __init__(self, token: str, max_depth: Optional[int] = None, verbose: bool = False):
+        self.token = token
+        self.max_depth = max_depth
+        self.verbose = verbose
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Notion-Version": NOTION_VERSION
+        }
+        self.base_url = "https://api.notion.com/v1"
+        self.pages: Dict[str, NotionPage] = {}
+        self.total_pages = 0
+
+    def discover_recursive(self, page_id: str, depth: int = 0, parent_id: Optional[str] = None) -> Optional[NotionPage]:
+        """
+        Recursively discover all child pages.
+
+        Args:
+            page_id: Page ID to start from
+            depth: Current recursion depth
+            parent_id: Parent page ID
+
+        Returns:
+            NotionPage with children populated
+        """
+        if self.max_depth is not None and depth > self.max_depth:
+            return None
+
+        page = self._fetch_page(page_id, parent_id, depth)
+        if not page:
+            return None
+
+        self.total_pages += 1
+        self.pages[page.id] = page
+
+        if self.verbose:
+            indent = "  " * depth
+            print(f"{indent}Found: {page.title}")
+
+        # Get child pages
+        child_page_ids = self._get_child_pages(page_id)
+
+        for child_id in child_page_ids:
+            child_page = self.discover_recursive(child_id, depth + 1, page.id)
+            if child_page:
+                page.children.append(child_page)
+                page.has_children = True
+
+        return page
+
+    def _fetch_page(self, page_id: str, parent_id: Optional[str], depth: int) -> Optional[NotionPage]:
+        """Fetch page metadata from Notion API."""
+        page_id = extract_page_id(page_id)
+        formatted_id = format_page_id(page_id)
+
+        response = requests.get(
+            f"{self.base_url}/pages/{formatted_id}",
+            headers=self.headers
+        )
+
+        if not response.ok:
+            if self.verbose:
+                print(f"Error fetching page {page_id}: {response.status_code}")
+            return None
+
+        data = response.json()
+
+        # Extract title
+        title = self._extract_title(data)
+
+        # Build URL
+        url = f"https://notion.so/{page_id.replace('-', '')}"
+
+        return NotionPage(
+            id=page_id,
+            title=title,
+            parent_id=parent_id,
+            url=url,
+            created_time=data.get('created_time', ''),
+            last_edited_time=data.get('last_edited_time', ''),
+            has_children=False,  # Will be updated when we find children
+            depth=depth
+        )
+
+    def _extract_title(self, page_data: Dict[str, Any]) -> str:
+        """Extract title from page properties."""
+        properties = page_data.get('properties', {})
+
+        # Try 'title' property
+        if 'title' in properties:
+            title_prop = properties['title']
+            if title_prop.get('title'):
+                return ''.join(t.get('plain_text', '') for t in title_prop['title'])
+
+        # Try 'Name' property (common in databases)
+        if 'Name' in properties:
+            name_prop = properties['Name']
+            if name_prop.get('title'):
+                return ''.join(t.get('plain_text', '') for t in name_prop['title'])
+
+        return "Untitled"
+
+    def _get_child_pages(self, page_id: str) -> List[str]:
+        """
+        Get IDs of all child pages under a page.
+
+        Child pages appear as 'child_page' block types in the blocks API.
+        """
+        child_page_ids = []
+        formatted_id = format_page_id(page_id)
+
+        has_more = True
+        start_cursor = None
+
+        while has_more:
+            params = {"page_size": 100}
+            if start_cursor:
+                params['start_cursor'] = start_cursor
+
+            response = requests.get(
+                f"{self.base_url}/blocks/{formatted_id}/children",
+                headers=self.headers,
+                params=params
+            )
+
+            if not response.ok:
+                break
+
+            data = response.json()
+            blocks = data.get('results', [])
+
+            for block in blocks:
+                if block['type'] == 'child_page':
+                    child_page_ids.append(block['id'])
+                # Note: child_database blocks could be handled in future
+
+            has_more = data.get('has_more', False)
+            start_cursor = data.get('next_cursor')
+
+        return child_page_ids
+
+
+class PathGenerator:
+    """Generates local file paths for pages."""
+
+    def __init__(self, output_dir: Path, flat_mode: bool = False):
+        self.output_dir = output_dir
+        self.flat_mode = flat_mode
+        self.paths: Dict[str, Path] = {}
+
+    def generate_paths(self, root: NotionPage, parent_path: Optional[Path] = None) -> None:
+        """
+        Generate local paths for all pages in hierarchy.
+
+        In hierarchical mode:
+        - Pages with children become directories with index.md
+        - Leaf pages become individual .md files
+
+        In flat mode:
+        - All pages become .md files in the output directory
+        """
+        if parent_path is None:
+            parent_path = self.output_dir
+
+        filename = sanitize_filename_strict(root.title) + '.md'
+
+        if self.flat_mode:
+            # Flat mode: all files in output directory
+            # Use depth prefix to avoid collisions
+            if root.depth > 0:
+                prefix = f"{root.depth:02d}_"
+            else:
+                prefix = ""
+            root.local_path = parent_path / f"{prefix}{filename}"
+        elif root.children:
+            # Hierarchical mode: page with children becomes directory
+            dir_path = parent_path / sanitize_filename_strict(root.title)
+            root.local_path = dir_path / 'index.md'
+
+            for child in root.children:
+                self.generate_paths(child, dir_path)
+        else:
+            # Leaf page is just a file
+            root.local_path = parent_path / filename
+
+        self.paths[root.id] = root.local_path
+
+
+class FrontmatterGenerator:
+    """Generates YAML frontmatter for markdown files."""
+
+    @staticmethod
+    def generate(page: NotionPage) -> str:
+        """
+        Generate YAML frontmatter for a page.
+
+        Args:
+            page: NotionPage object
+
+        Returns:
+            YAML frontmatter string (without --- delimiters)
+        """
+        data = {
+            'notion_id': page.id,
+            'notion_url': page.url,
+            'title': page.title,
+            'parent_id': page.parent_id,
+            'created_time': page.created_time,
+            'last_edited_time': page.last_edited_time,
+            'downloaded_at': datetime.now().isoformat(),
+            'has_children': page.has_children
+        }
+
+        lines = []
+        for key, value in data.items():
+            if value is None:
+                lines.append(f'{key}: null')
+            elif isinstance(value, bool):
+                lines.append(f'{key}: {str(value).lower()}')
+            else:
+                # Quote strings with special characters
+                str_value = str(value)
+                if ':' in str_value or '"' in str_value or str_value.startswith('{'):
+                    # Escape internal quotes and wrap
+                    escaped = str_value.replace('"', '\\"')
+                    lines.append(f'{key}: "{escaped}"')
+                else:
+                    lines.append(f'{key}: {str_value}')
+
+        return '\n'.join(lines) + '\n'
+
+
+class NotionToMarkdownConverter:
+    """Convert Notion blocks to markdown."""
+
+    def __init__(self, output_dir: Path, page_name: str = "page"):
+        self.output_dir = output_dir
+        self.page_name = sanitize_filename_strict(page_name)
+        self.images_dir = output_dir / "images" / self.page_name
+        self.image_counter = 0
+
+    def blocks_to_markdown(self, blocks: List[Dict[str, Any]]) -> str:
+        """Convert Notion blocks to markdown."""
+        lines = []
+
+        for block in blocks:
+            block_type = block.get('type')
+
+            if block_type == 'paragraph':
+                lines.append(self._paragraph_to_md(block))
+            elif block_type == 'heading_1':
+                lines.append(self._heading_to_md(block, 1))
+            elif block_type == 'heading_2':
+                lines.append(self._heading_to_md(block, 2))
+            elif block_type == 'heading_3':
+                lines.append(self._heading_to_md(block, 3))
+            elif block_type == 'bulleted_list_item':
+                lines.append(self._bulleted_list_to_md(block))
+            elif block_type == 'numbered_list_item':
+                lines.append(self._numbered_list_to_md(block))
+            elif block_type == 'code':
+                lines.append(self._code_to_md(block))
+            elif block_type == 'quote':
+                lines.append(self._quote_to_md(block))
+            elif block_type == 'callout':
+                lines.append(self._callout_to_md(block))
+            elif block_type == 'divider':
+                lines.append("---")
+            elif block_type == 'image':
+                lines.append(self._image_to_md(block))
+            elif block_type == 'to_do':
+                lines.append(self._todo_to_md(block))
+            elif block_type == 'toggle':
+                lines.append(self._toggle_to_md(block))
+            elif block_type == 'child_page':
+                # Child pages are handled separately in recursive download
+                lines.append(f"<!-- Child page: {block.get('child_page', {}).get('title', 'Unknown')} -->")
+            elif block_type == 'child_database':
+                lines.append(f"<!-- Child database: {block.get('child_database', {}).get('title', 'Unknown')} -->")
+            else:
+                lines.append(f"<!-- Unsupported block type: {block_type} -->")
+
+            lines.append("")
+
+        return '\n'.join(lines)
+
+    def _extract_text(self, rich_text: List[Dict[str, Any]]) -> str:
+        """Extract text with markdown formatting from rich text objects."""
+        if not rich_text:
+            return ""
+
+        parts = []
+        for text_obj in rich_text:
+            text = text_obj.get('plain_text', '')
+            annotations = text_obj.get('annotations', {})
+
+            if annotations.get('bold'):
+                text = f"**{text}**"
+            if annotations.get('italic'):
+                text = f"*{text}*"
+            if annotations.get('code'):
+                text = f"`{text}`"
+            if annotations.get('strikethrough'):
+                text = f"~~{text}~~"
+
+            if text_obj.get('href'):
+                text = f"[{text}]({text_obj['href']})"
+
+            parts.append(text)
+
+        return ''.join(parts)
+
+    def _paragraph_to_md(self, block: Dict[str, Any]) -> str:
+        return self._extract_text(block['paragraph'].get('rich_text', []))
+
+    def _heading_to_md(self, block: Dict[str, Any], level: int) -> str:
+        heading_key = f'heading_{level}'
+        text = self._extract_text(block[heading_key].get('rich_text', []))
+        return f"{'#' * level} {text}"
+
+    def _bulleted_list_to_md(self, block: Dict[str, Any]) -> str:
+        text = self._extract_text(block['bulleted_list_item'].get('rich_text', []))
+        return f"- {text}"
+
+    def _numbered_list_to_md(self, block: Dict[str, Any]) -> str:
+        text = self._extract_text(block['numbered_list_item'].get('rich_text', []))
+        return f"1. {text}"
+
+    def _code_to_md(self, block: Dict[str, Any]) -> str:
+        code_data = block['code']
+        code = self._extract_text(code_data.get('rich_text', []))
+        language = code_data.get('language', 'text')
+        return f"```{language}\n{code}\n```"
+
+    def _quote_to_md(self, block: Dict[str, Any]) -> str:
+        text = self._extract_text(block['quote'].get('rich_text', []))
+        return f"> {text}"
+
+    def _callout_to_md(self, block: Dict[str, Any]) -> str:
+        callout_data = block['callout']
+        icon = callout_data.get('icon', {})
+        icon_str = ""
+        if icon.get('type') == 'emoji':
+            icon_str = icon.get('emoji', '')
+
+        text = self._extract_text(callout_data.get('rich_text', []))
+        return f"> {icon_str} {text}"
+
+    def _todo_to_md(self, block: Dict[str, Any]) -> str:
+        todo_data = block['to_do']
+        checked = todo_data.get('checked', False)
+        text = self._extract_text(todo_data.get('rich_text', []))
+        checkbox = "[x]" if checked else "[ ]"
+        return f"- {checkbox} {text}"
+
+    def _toggle_to_md(self, block: Dict[str, Any]) -> str:
+        toggle_data = block['toggle']
+        text = self._extract_text(toggle_data.get('rich_text', []))
+        # Toggles become details/summary in markdown
+        return f"<details>\n<summary>{text}</summary>\n\n<!-- Toggle content -->\n\n</details>"
+
+    def _image_to_md(self, block: Dict[str, Any]) -> str:
+        """Download image and return markdown reference."""
+        image_data = block['image']
+        image_type = image_data.get('type')
+
+        url = None
+        if image_type == 'external':
+            url = image_data['external'].get('url')
+        elif image_type == 'file':
+            url = image_data['file'].get('url')
+
+        if not url:
+            return "<!-- Image URL not found -->"
+
+        try:
+            self.image_counter += 1
+
+            # Determine extension
+            ext = '.png'
+            url_lower = url.lower()
+            if '.jpg' in url_lower or '.jpeg' in url_lower:
+                ext = '.jpg'
+            elif '.gif' in url_lower:
+                ext = '.gif'
+            elif '.webp' in url_lower:
+                ext = '.webp'
+            elif '.svg' in url_lower:
+                ext = '.svg'
+
+            # Contextual filename
+            filename = f"{self.page_name}_image_{self.image_counter:02d}{ext}"
+            ensure_directory(self.images_dir)
+            filepath = self.images_dir / filename
+
+            # Download
+            response = requests.get(url, timeout=30)
+            if response.ok:
+                filepath.write_bytes(response.content)
+                # Calculate relative path from markdown file to image
+                rel_path = f"images/{self.page_name}/{filename}"
+                return f"![Image]({rel_path})"
+            else:
+                return f"<!-- Failed to download image: {url} -->"
+
+        except Exception as e:
+            return f"<!-- Error downloading image: {e} -->"
+
+
+class RecursiveDownloader:
+    """Main orchestrator for recursive Notion download."""
+
+    def __init__(
+        self,
+        token: str,
+        output_dir: Path,
+        max_depth: Optional[int] = None,
+        flat_mode: bool = False,
+        include_images: bool = True,
+        verbose: bool = False,
+        dry_run: bool = False
+    ):
+        self.token = token
+        self.output_dir = output_dir
+        self.max_depth = max_depth
+        self.flat_mode = flat_mode
+        self.include_images = include_images
+        self.verbose = verbose
+        self.dry_run = dry_run
+
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Notion-Version": NOTION_VERSION
+        }
+        self.base_url = "https://api.notion.com/v1"
+
+        self.hierarchy = PageHierarchy(token, max_depth, verbose)
+        self.path_gen = PathGenerator(output_dir, flat_mode)
+        self.mapping: Dict[str, Any] = {}
+        self.stats = {
+            'total_pages': 0,
+            'total_images': 0,
+            'max_depth': 0
+        }
+
+    def download_recursive(self, page_id: str) -> int:
+        """
+        Main entry point for recursive download.
+
+        Args:
+            page_id: Root page ID or URL
+
+        Returns:
+            Number of pages downloaded
+        """
+        page_id = extract_page_id(page_id)
+
+        # Phase 1: Discover
+        print("=" * 60)
+        print("PHASE 1: Discovering page hierarchy")
+        print("=" * 60)
+
+        root = self.hierarchy.discover_recursive(page_id)
+        if not root:
+            print("Failed to fetch root page")
+            return 0
+
+        # Generate paths
+        self.path_gen.generate_paths(root)
+
+        # Calculate stats
+        self._calculate_stats(root)
+
+        print(f"\nDiscovered {self.stats['total_pages']} pages")
+        print(f"Max depth: {self.stats['max_depth']}")
+
+        if self.dry_run:
+            print("\n" + "=" * 60)
+            print("DRY RUN - Would create the following structure:")
+            print("=" * 60)
+            self._print_tree(root)
+            return 0
+
+        # Phase 2: Download
+        print("\n" + "=" * 60)
+        print("PHASE 2: Downloading content")
+        print("=" * 60)
+
+        # Create directories
+        ensure_directory(self.output_dir)
+
+        # Download all pages
+        downloaded = self._download_page_tree(root)
+
+        # Save mapping
+        self._save_mapping(root)
+
+        print("\n" + "=" * 60)
+        print("DOWNLOAD COMPLETE")
+        print("=" * 60)
+        print(f"Pages downloaded: {downloaded}")
+        print(f"Images downloaded: {self.stats['total_images']}")
+        print(f"Output directory: {self.output_dir}")
+        print(f"Mapping file: {self.output_dir / 'mapping.json'}")
+
+        return downloaded
+
+    def _calculate_stats(self, page: NotionPage) -> None:
+        """Calculate statistics from page tree."""
+        self.stats['total_pages'] += 1
+        self.stats['max_depth'] = max(self.stats['max_depth'], page.depth)
+
+        for child in page.children:
+            self._calculate_stats(child)
+
+    def _print_tree(self, page: NotionPage, indent: int = 0) -> None:
+        """Print page tree structure."""
+        prefix = "  " * indent
+        local_path = page.local_path.relative_to(self.output_dir) if page.local_path else "???"
+        print(f"{prefix}{'[D]' if page.children else '[F]'} {page.title} -> {local_path}")
+
+        for child in page.children:
+            self._print_tree(child, indent + 1)
+
+    def _download_page_tree(self, page: NotionPage) -> int:
+        """Download a page and all its children."""
+        count = 0
+
+        if self._download_single_page(page):
+            count += 1
+
+        for child in page.children:
+            count += self._download_page_tree(child)
+
+        return count
+
+    def _download_single_page(self, page: NotionPage) -> bool:
+        """Download one page with frontmatter."""
+        if self.verbose:
+            print(f"Downloading: {page.title}")
+
+        # Get blocks
+        blocks = self._get_blocks(page.id)
+
+        # Convert to markdown
+        converter = NotionToMarkdownConverter(self.output_dir, page.title)
+        markdown = converter.blocks_to_markdown(blocks)
+        self.stats['total_images'] += converter.image_counter
+
+        # Generate frontmatter
+        frontmatter = FrontmatterGenerator.generate(page)
+        content = f"---\n{frontmatter}---\n\n# {page.title}\n\n{markdown}"
+
+        # Save to file
+        ensure_directory(page.local_path.parent)
+        page.local_path.write_text(content, encoding='utf-8')
+
+        # Update mapping
+        rel_path = str(page.local_path.relative_to(self.output_dir))
+        self.mapping[rel_path] = {
+            'notion_id': page.id,
+            'title': page.title,
+            'parent_id': page.parent_id,
+            'has_children': page.has_children,
+            'child_paths': [
+                str(c.local_path.relative_to(self.output_dir))
+                for c in page.children
+            ] if page.children else []
+        }
+
+        return True
+
+    def _get_blocks(self, page_id: str) -> List[Dict[str, Any]]:
+        """Retrieve all blocks from a page (not recursing into child pages)."""
+        all_blocks = []
+        formatted_id = format_page_id(page_id)
+        has_more = True
+        start_cursor = None
+
+        while has_more:
+            params = {"page_size": 100}
+            if start_cursor:
+                params['start_cursor'] = start_cursor
+
+            response = requests.get(
+                f"{self.base_url}/blocks/{formatted_id}/children",
+                headers=self.headers,
+                params=params
+            )
+
+            if not response.ok:
+                if self.verbose:
+                    print(f"Error getting blocks: {response.status_code}")
+                break
+
+            data = response.json()
+            blocks = data.get('results', [])
+            all_blocks.extend(blocks)
+
+            has_more = data.get('has_more', False)
+            start_cursor = data.get('next_cursor')
+
+        return all_blocks
+
+    def _save_mapping(self, root: NotionPage) -> None:
+        """Save mapping.json file."""
+        mapping_data = {
+            'source': {
+                'notion_id': root.id,
+                'title': root.title,
+                'url': root.url
+            },
+            'downloaded_at': datetime.now().isoformat(),
+            'pages': self.mapping,
+            'statistics': self.stats
+        }
+
+        mapping_path = self.output_dir / 'mapping.json'
+        mapping_path.write_text(
+            json.dumps(mapping_data, indent=2, ensure_ascii=False),
+            encoding='utf-8'
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recursively download Notion pages as markdown",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s PAGE_ID --output ./docs/
+  %(prog)s PAGE_URL --dry-run
+  %(prog)s PAGE_ID --flat --output ./flat_docs/
+  %(prog)s PAGE_ID --max-depth 2 --verbose
+
+File Naming:
+  - All lowercase, underscores instead of spaces
+  - "Design Overview" -> design_overview.md
+  - "API Reference (v2)" -> api_reference_v2.md
+
+Output Structure (default):
+  output/
+  ├── parent_page/
+  │   ├── index.md
+  │   ├── child_1.md
+  │   └── child_2/
+  │       ├── index.md
+  │       └── grandchild.md
+  ├── images/
+  │   ├── parent_page/
+  │   └── child_1/
+  └── mapping.json
+"""
+    )
+
+    parser.add_argument(
+        "page_id",
+        help="Notion page ID or URL to download recursively"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output directory (default: {DEFAULT_OUTPUT_DIR})"
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=None,
+        help="Maximum recursion depth (default: unlimited)"
+    )
+    parser.add_argument(
+        "--flat",
+        action="store_true",
+        help="Flatten hierarchy (no subdirectories)"
+    )
+    parser.add_argument(
+        "--no-images",
+        action="store_true",
+        help="Skip downloading images"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be downloaded without actually downloading"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Verbose output"
+    )
+
+    args = parser.parse_args()
+
+    # Find token
+    token = find_notion_token()
+    if not token:
+        print("Error: NOTION_TOKEN not found!")
+        print("  Create .env.notion with NOTION_TOKEN=your_token")
+        print("  Or set NOTION_TOKEN environment variable")
+        sys.exit(1)
+
+    # Create downloader
+    output_dir = Path(args.output)
+    downloader = RecursiveDownloader(
+        token=token,
+        output_dir=output_dir,
+        max_depth=args.max_depth,
+        flat_mode=args.flat,
+        include_images=not args.no_images,
+        verbose=args.verbose,
+        dry_run=args.dry_run
+    )
+
+    # Run
+    count = downloader.download_recursive(args.page_id)
+
+    if args.dry_run:
+        print("\nRun without --dry-run to actually download.")
+    elif count == 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements two-phase recursive download capability for Notion pages:

New Features:
- notion_download_recursive.py: Downloads page hierarchies
  - Phase 1: Discover all child pages recursively
  - Phase 2: Download with YAML frontmatter metadata
  - Strict file naming (lowercase, underscores, no special chars)
  - mapping.json for round-trip sync
  - Dry-run mode for preview
  - Flat mode option

- YAML frontmatter includes notion_id, title, timestamps
- Contextual image naming: images/{page_name}/{page_name}_image_01.png
- mapping.json with page-to-file mappings for future uploads

New Files:
- scripts/notion_download_recursive.py (550 lines)
- guides/workflows/recursive-download-workflow.md

Updated:
- scripts/notion_utils.py: Added sanitize_filename_strict()
- SKILL.md: Added Intent #2b for recursive downloads
- README.md: Added recursive download documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)